### PR TITLE
backend: route `api/todos` now serves crud operations

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -1,9 +1,15 @@
-const express = require('express');
+import express from 'express';
+import todoRoutes from './routes/todoRoutes.js';
 
 const app = express();
 
 const host = 'localhost';
 const port = 3000;
+
+app.use(express.json());
+app.use(express.urlencoded({ extended: false }));
+
+app.use('/api/todos', todoRoutes);
 
 app.get('/', (req, res) => {
   res.send('todo server is online');

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -1,0 +1,2 @@
+//mocking db stuff for now..
+// Issue #17 will conver db integration.

--- a/server/package.json
+++ b/server/package.json
@@ -2,8 +2,10 @@
   "name": "server",
   "version": "1.0.0",
   "main": "index.js",
+  "type": "module",
   "scripts": {
     "start": "node app.js",
+    "dev": "node --watch app.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],

--- a/server/routes/todoRoutes.js
+++ b/server/routes/todoRoutes.js
@@ -1,0 +1,101 @@
+import express from 'express';
+
+const router = express.Router();
+
+let todos = [
+  { id: 1, title: 'Buy groceries', completed: false, createdAt: '' },
+  { id: 2, title: 'Walk the dog', completed: true, createdAt: '' },
+  { id: 3, title: 'Read a book', completed: false, createdAt: '' },
+  { id: 4, title: 'bla bla', completed: true, createdAt: '' }
+];
+
+//'/api/todos';
+router.get('/', async (req, res) => {
+  try {
+    return res.status(200).json({
+      data: todos
+    });
+  } catch (error) {
+    res.send({
+      error: 'nope'
+    });
+  }
+});
+
+router.get('/:id', async (req, res) => {
+  try {
+    const id = parseInt(req.params.id);
+    const todo = todos.find((todo) => todo.id == id);
+
+    if (!todo) {
+      return res
+        .status(404)
+        .json({ msg: `could not find a Todo with id: ${id}` });
+    }
+
+    res.status(200).json({ data: todo });
+  } catch (error) {
+    res.send({
+      error: 'nope'
+    });
+  }
+});
+
+router.post('/', async (req, res) => {
+  try {
+    const newTodo = {
+      id: Math.floor(Math.random() * 100),
+      tite: req.body.title || 'Untitled Todo',
+      completed: false,
+      createdAt: req.body.createdAt
+    };
+
+    todos.push(newTodo);
+
+    res.status(201).json({ message: 'new Todo added.' });
+  } catch (error) {
+    res.status(400).send({
+      error: 'nope'
+    });
+  }
+});
+
+router.put('/:id', async (req, res) => {
+  try {
+    const id = parseInt(req.params.id);
+    const todo = todos.find((todo) => todo.id == id);
+
+    if (!todo) {
+      return res.status(404).json({ msg: `Todo with id: ${id} was not found` });
+    }
+
+    todo.title = req.body.title;
+    res.status(200).json(todos);
+  } catch (error) {
+    res.status(400).send({
+      error: 'nope'
+    });
+  }
+});
+
+router.delete('/:id', async (req, res) => {
+  try {
+    const id = parseInt(req.params.id);
+    const todo = todos.find((todo) => todo.id == id);
+    if (!todo) {
+      return res
+        .status(404)
+        .json({ msg: 'Todo does not exist. cannot delete.' });
+    }
+
+    todos = todos.filter((todo) => todo.id !== id);
+
+    res.status(201).json({ data: todos });
+  } catch (error) {
+    res.status(400).send({
+      error: 'delete failed'
+    });
+  }
+});
+
+export default router;


### PR DESCRIPTION
this PR makes following endpoints available for the frontend,

`GET /todos/:id`- Returns a specific todo item identified by its ID.
`GET /todos` - Retrieve a list of all todos - Returns a list of all todo items.

`POST /todos` - Create a new todo item
**Body (raw)**
`{
    "title":"aliquam-quo-nesciunt",
    "description":"ut voluptatem officiis",
    "completed" : "false",
    "createdAt" : "Tue Apr 01 2025 23:40:52 GMT+0530 (India Standard Time)"
}`

`PUT /todos/:id` - Update an existing todo item with it's id same as `id`.

`DELETE /todo/:id` - Delete a post based on it's id.
